### PR TITLE
fix: specify type declaration file more precisely

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./dist/defu.js",
   "browser": "./dist/defu.min.js",
-  "types": "./types",
+  "types": "./types/defu.d.ts",
   "files": [
     "dist",
     "types"


### PR DESCRIPTION
(In another project) `rollup` struggled to recognise the types for `defu` without this change.